### PR TITLE
Bug prevent repeated openstreetmap calls with empty user array

### DIFF
--- a/pages/admin/case/add.js
+++ b/pages/admin/case/add.js
@@ -75,12 +75,16 @@ export default function AdminCaseAdd() {
       let distances = []
       for (const user of users?.filter(u => u.newsletter && !u.newsletter_deactivated && !u.newsletter_bounced && u.status === 'USER')) {
 
-        if (user.lat === null || user.lon === null) continue
-        
+        if (user.lat === null || user.lon === null) {
+
+          distances.push(9999999)
+          continue
+        }
+
         const distance = getDistanceFromLatLonInKm(location[0].lat, location[0].lon, user.lat, user.lon)
         distances.push(distance)
       }
-      setAllDistancesOfUsers(distances)
+      setAllDistancesOfUsers(distances.length > 0 ? distances : [9999999])
     }
 
     if (formZipcode.length === 5 && allDistancesOfUsers.length === 0 && formSearchRadius > 0) {

--- a/pages/admin/case/add.js
+++ b/pages/admin/case/add.js
@@ -75,11 +75,7 @@ export default function AdminCaseAdd() {
       let distances = []
       for (const user of users?.filter(u => u.newsletter && !u.newsletter_deactivated && !u.newsletter_bounced && u.status === 'USER')) {
 
-        if (user.lat === null || user.lon === null) {
-
-          distances.push(9999999)
-          continue
-        }
+        if (user.lat === null || user.lon === null) continue
 
         const distance = getDistanceFromLatLonInKm(location[0].lat, location[0].lon, user.lat, user.lon)
         distances.push(distance)


### PR DESCRIPTION
Im Fall, dass kein User in der Datenbank vorhanden ist (User mit Status 'User'), wird die openstreetmap api in einer "Endlosschleife" aufgerufen, weil das Distanzen Array immer leer bleibt. 

Das Distanzen Array wird jetzt künstlich mit einem sehr hohen Wert befüllt um sicherzustellen, dass die openstreetmap api auch nur einmal angefragt wird.