### PR TITLE
Bug message api without token

### DIFF
--- a/pages/api/messages.js
+++ b/pages/api/messages.js
@@ -22,7 +22,14 @@ export default async function handler(request, response) {
     return deg * (Math.PI/180)
   }
 
-  const user = await getToken(request).then(token => token.user)
+  const token = await getToken(request)
+
+  if (!token) {
+    response.status(401).send([])
+    return
+  }
+
+  const user = token.user
 
   logger.info(`api | messages`)
 


### PR DESCRIPTION
Im ausgeloggten Zustand wird auf der Index Seite die Message Api angefragt. Da die Message Api seit dem letzten Update Werte der Session benutzt, kommt es zu einem Fehler. Jetzt wird geprüft ob eine Session vorhanden ist.