### PR TITLE
Feature add more emails to queue

### DIFF
--- a/lib/queue/sendToQueue.js
+++ b/lib/queue/sendToQueue.js
@@ -15,10 +15,10 @@ const sendToQueue = async (type, payload, options = {}) => {
     
     let newExecuteAt = new Date()
 
-    if (getCurrentQueue.rows.length > 0 && new Date(`${getCurrentQueue.rows[0].execute_at}Z`).getTime() >= new Date().setSeconds(new Date().getSeconds() - 90)) {
+    if (getCurrentQueue.rows.length > 0 && new Date(`${getCurrentQueue.rows[0].execute_at}Z`).getTime() >= new Date().setSeconds(new Date().getSeconds() - 45)) {
 
-      // 90 Sekunden Abstand zwischen den Emails = 40 Emails pro Stunde
-      newExecuteAt = new Date(new Date(getCurrentQueue.rows[0].execute_at).setSeconds(new Date(getCurrentQueue.rows[0].execute_at).getSeconds() + 90))
+      // 45 Sekunden Abstand zwischen den Emails = 80 Emails pro Stunde
+      newExecuteAt = new Date(new Date(getCurrentQueue.rows[0].execute_at).setSeconds(new Date(getCurrentQueue.rows[0].execute_at).getSeconds() + 45))
     }
 
     const queueRequest = await db.query(

--- a/pages/api/admin/case/accept.js
+++ b/pages/api/admin/case/accept.js
@@ -1,7 +1,7 @@
 import getToken from '../../../../lib/auth/getToken'
 import logger from '../../../../lib/logger'
 import db from '../../../../lib/db'
-import sendMail from '../../../../lib/sendMail'
+import { sendToQueue } from '../../../../lib/queue'
 
 export default async function handler(request, response) {
 
@@ -62,7 +62,7 @@ export default async function handler(request, response) {
         ]
       )
 
-      logger.info(`api | admin | case | accept | PATCH | send mail`)
+      logger.info(`api | admin | case | accept | PATCH | send mail to queue`)
 
       const templateName = 'acceptedHelpNotification'
       const subject = 'Hilfe angenommen'
@@ -71,13 +71,14 @@ export default async function handler(request, response) {
         firstname: helperRequest.rows[0].firstname,
       }
 
-      const sent = await sendMail(helperRequest.rows[0].email, subject, templateName, params)
-
-      if (sent.statusCode === 200) {
-        logger.info(`api | admin | case | accept | PATCH | send mail | sent`)
-      } else {
-        logger.info(`api | admin | case | accept | PATCH | send mail | error`)
+      const data = {
+        email: helperRequest.rows[0].email,
+        emailSubject: subject,
+        templateName: templateName,
+        params: params,
       }
+
+      await sendToQueue('MAIN', data)
 
       response.status(200).json(dbRequest.rows[0] || {})
 

--- a/pages/api/admin/user/newsletter.js
+++ b/pages/api/admin/user/newsletter.js
@@ -4,7 +4,7 @@ import logger from '../../../../lib/logger'
 import jwt from 'jsonwebtoken'
 import CryptoJS from 'crypto-js'
 import { randomUUID } from 'crypto'
-import {sendToQueue} from '../../../../lib/queue'
+import { sendToQueue } from '../../../../lib/queue'
 
 export default async function handler(request, response) {
 

--- a/pages/api/deactivateNewsletter.js
+++ b/pages/api/deactivateNewsletter.js
@@ -2,7 +2,7 @@ import logger from '../../lib/logger'
 import db from '../../lib/db'
 import jwt from 'jsonwebtoken'
 import CryptoJS from 'crypto-js'
-import sendMail from '../../lib/sendMail'
+import { sendToQueue } from '../../lib/queue'
 
 export default async function handler(request, response) {
 
@@ -60,7 +60,14 @@ export default async function handler(request, response) {
         lastname: dbRequest.rows[0].lastname,
       }
 
-      sent = await sendMail(to, subject, templateName, params)
+      const data = {
+        email: to,
+        emailSubject: subject,
+        templateName: templateName,
+        params: params,
+      }
+
+      await sendToQueue('MAIN', data)
 
       if (sent.statusCode === 200) {
         logger.info(`${request.url.slice(0, 50)} | ${request.method} | delete account | send mail | sent`)


### PR DESCRIPTION
Bisher waren nur die Newsletter Emails in die Queue ausgelagert. Jetzt werden auch andere Emails über die Queue versandt, die nicht darauf angewiesen sind, dass sie sofort kommen (wie der Verifizierungscode beim Einloggen). 

Außerdem habe ich die Interval Rate der E-Mails erhöht von 40 auf 80 Mails pro Stunde.